### PR TITLE
Nullable foreach value

### DIFF
--- a/src/Normalizer/NetworkSettingsNormalizer.php
+++ b/src/Normalizer/NetworkSettingsNormalizer.php
@@ -57,8 +57,12 @@ class NetworkSettingsNormalizer implements DenormalizerInterface, NormalizerInte
             $values = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
             foreach ($data->{'Ports'} as $key => $value) {
                 $values_1 = [];
-                foreach ($value as $value_1) {
-                    $values_1[] = $this->denormalizer->denormalize($value_1, 'Docker\\API\\Model\\PortBinding', 'json', $context);
+                if (is_iterable($value)){
+                    foreach ($value as $value_1) {
+                        $values_1[] = $this->denormalizer->denormalize($value_1, 'Docker\\API\\Model\\PortBinding', 'json', $context);
+                    }
+                } else {
+                    $values_1[] = $this->denormalizer->denormalize(null, 'Docker\\API\\Model\\PortBinding', 'json', $context);
                 }
                 $values[$key] = $values_1;
             }


### PR DESCRIPTION
ErrorException thrown with message "Invalid argument supplied for foreach()"

Stacktrace:
```
#65 ErrorException in /path/vendor/docker-php/docker-php-api/src/Normalizer/NetworkSettingsNormalizer.php:60
#64 Illuminate\Foundation\Bootstrap\HandleExceptions:handleError in /path/vendor/docker-php/docker-php-api/src/Normalizer/NetworkSettingsNormalizer.php:60
#63 Docker\API\Normalizer\NetworkSettingsNormalizer:denormalize in /path/vendor/symfony/serializer/Serializer.php:177
#62 Symfony\Component\Serializer\Serializer:denormalize in /path/vendor/docker-php/docker-php-api/src/Normalizer/ContainersIdJsonGetResponse200Normalizer.php:122
#61 Docker\API\Normalizer\ContainersIdJsonGetResponse200Normalizer:denormalize in /path/vendor/symfony/serializer/Serializer.php:177
#60 Symfony\Component\Serializer\Serializer:denormalize in /path/vendor/symfony/serializer/Serializer.php:128
#59 Symfony\Component\Serializer\Serializer:deserialize in /path/vendor/docker-php/docker-php-api/src/Endpoint/ContainerInspect.php:76
#58 Docker\API\Endpoint\ContainerInspect:transformResponseBody in /path/vendor/jane-php/open-api-runtime/Client/Psr7HttplugEndpointTrait.php:18
#57 Docker\API\Endpoint\ContainerInspect:parsePSR7Response in /path/vendor/jane-php/open-api-runtime/Client/Psr7HttplugClient.php:48
#56 Jane\OpenApiRuntime\Client\Psr7HttplugClient:executePsr7Endpoint in /path/vendor/docker-php/docker-php-api/src/Client.php:81
#55 Docker\API\Client:containerInspect in /path/app/Http/Controllers/DockerController.php:113

```


`…/vendor/docker-php/docker-php-api/src/Normalizer/NetworkSettingsNormalizer.php:60`

Fragment of docker inspect command:

               "8302/udp": null,
                "8500/tcp": [
                    {
                        "HostIp": "0.0.0.0",
                        "HostPort": "32792"
                    }
                ],